### PR TITLE
Fix fatal in goroutine

### DIFF
--- a/ssh_client_stream_test.go
+++ b/ssh_client_stream_test.go
@@ -63,7 +63,7 @@ func Test_newClientStream(t *testing.T) {
 		go func(r string) {
 			defer wg.Done()
 			if err := sess.Send(&Packet{Data: []byte(r)}); err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 		}(r)
 
@@ -72,11 +72,11 @@ func Test_newClientStream(t *testing.T) {
 			defer wg.Done()
 			res1, err := sess.Recv()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			res2, err := sess.Recv()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			mux.Lock()
 			defer mux.Unlock()

--- a/ssh_packet.go
+++ b/ssh_packet.go
@@ -26,7 +26,7 @@ func (p *Packet) Write(w io.Writer) error {
 	return nil
 }
 
-// ReadPacker reads Packet data from Reader
+// ReadPacket reads Packet data from Reader
 func ReadPacket(r io.Reader) (*Packet, error) {
 	header := make([]byte, 4) // TODO: define protocol
 	if _, err := r.Read(header); err != nil {

--- a/ssh_server_stream_test.go
+++ b/ssh_server_stream_test.go
@@ -71,7 +71,7 @@ func Test_newServerStream(t *testing.T) {
 
 	go func() {
 		if err := server.Listen(context.Background()); err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 	}()
 
@@ -95,7 +95,7 @@ func Test_newServerStream(t *testing.T) {
 		go func(r string) {
 			defer wg.Done()
 			if err := sess.Send(&Packet{Data: []byte(r)}); err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 		}(r)
 
@@ -104,11 +104,11 @@ func Test_newServerStream(t *testing.T) {
 			defer wg.Done()
 			res1, err := sess.Recv()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			res2, err := sess.Recv()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			mux.Lock()
 			defer mux.Unlock()

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -118,12 +118,12 @@ func testSSHServer(t *testing.T, config *ssh.ServerConfig, handlers map[string]s
 	go func() {
 		conn, err := l.Accept()
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 
 		sshConn, chans, _, err := ssh.NewServerConn(conn, config)
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		defer sshConn.Close()
 
@@ -160,7 +160,7 @@ func testSSHServer(t *testing.T, config *ssh.ServerConfig, handlers map[string]s
 				cmd := string(req.Payload[4:])
 				handler, ok := handlers[cmd]
 				if !ok {
-					t.Fatal("handler not found: %s" + cmd)
+					panic("handler not found: " + cmd)
 				}
 
 				for {
@@ -169,7 +169,7 @@ func testSSHServer(t *testing.T, config *ssh.ServerConfig, handlers map[string]s
 						break
 					}
 					if err != nil {
-						t.Fatal(err)
+						panic(err)
 					}
 					if handler(p, ch) {
 						break


### PR DESCRIPTION
from https://github.com/minio/minio/pull/6682
`t.Fatal` and `t.Fatalf` must be called from the same goroutine running the Test function, see https://godoc.org/testing#T.